### PR TITLE
Rework makefile to ease packaging

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,21 @@
-PREFIX = /usr/local
+DESTDIR ?=
+PREFIX ?= /usr/local
+CXX ?= g++
+CXXFLAGS ?= -O3
+CXXFLAGS += -Wall -Wextra -Werror
+LDFLAGS ?=
 
-g++:	qpress.cpp aio.cpp quicklz.c utilities.cpp
-	g++ -O3 -o qpress -x c quicklz.c -x c++ qpress.cpp aio.cpp utilities.cpp -lpthread -Wall -Wextra -Werror
+qpress:	qpress.cpp aio.cpp quicklz.c utilities.cpp
+	$(CXX) $(CXXFLAGS) -o qpress -x c quicklz.c -x c++ qpress.cpp aio.cpp utilities.cpp -lpthread $(LDFLAGS)
 
 install: qpress
-	install -m 0755 qpress $(PREFIX)/bin
+	install -D -p -m 0755 -t $(DESTDIR)$(PREFIX)/bin qpress
 
-.PHONY: install g++
+clean:
+	rm -f qpress
+
+all: qpress
+
+g++: qpress
+
+.PHONY: clean install


### PR DESCRIPTION
- rename default target to `qpress`
- add DESTDIR support
- add clean target
- allow overriding the compiler and the build flags