### PR TITLE
Fix snprintf argument in utilities.cpp

### DIFF
--- a/utilities.cpp
+++ b/utilities.cpp
@@ -223,7 +223,7 @@ string delimiter(long long l)
 #ifdef WINDOWS
     sprintf(s, "%I64d", l);
 #else
-    sprintf(s, "%lld", l);
+    snprintf(s, sizeof(s), "%lld", l);
 #endif
     for(i = 0; i < strlen(s); i++)
     {


### PR DESCRIPTION
Describe the issue: On macOS 12.6.3 compilation environment, using the sprintf() function generates a warning, and it is recommended to use the snprintf() function instead. Additionally, when using the snprintf() function, the buffer size parameter needs to be correctly passed.

Describe the solution: Replace the sprintf() function with the snprintf() function and correctly pass the buffer size parameter.

Submit code changes: Include the changes you made, such as modifying sprintf(s, "%lld", l); to snprintf(s, sizeof(s), "%lld", l);.