### PR TITLE
qpress.cpp: fix compilation on the FreeBSD

### DIFF
--- a/qpress.cpp
+++ b/qpress.cpp
@@ -95,7 +95,7 @@ and finally outputs an UPDIR:
 #include "levels.c"
 #include "utilities.hpp"
 
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
     #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Currently it is handled as a local patch in the port, would be nice to fix in the upstream